### PR TITLE
Feat: Add .gitignore file and exclude node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
This PR adds the `.gitignore` file to the repository, ensuring that unnecessary files and directories are excluded from version control. Additionally, the node_modules directory has been added to the .gitignore file to prevent it from being tracked by Git.

This update helps maintain a cleaner repository and ensures that only necessary files are included in the version history. Developers can still generate the node_modules directory using `npm install` or yarn install based on the information in the `package.json` file.

Let me know if further enhancements modifications are required
Thank you